### PR TITLE
Fluent design

### DIFF
--- a/GX Password/App.xaml.cs
+++ b/GX Password/App.xaml.cs
@@ -33,13 +33,13 @@ namespace GX_Password
 
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-//#if DEBUG
-//            if (System.Diagnostics.Debugger.IsAttached)
-//            {
-//                this.DebugSettings.EnableFrameRateCounter = true;
-//            }
-//#endif
-			Frame rootFrame = Window.Current.Content as Frame;
+#if DEBUG
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                this.DebugSettings.EnableFrameRateCounter = true;
+            }
+#endif
+            Frame rootFrame = Window.Current.Content as Frame;
 
             if (rootFrame == null)
             {
@@ -62,12 +62,6 @@ namespace GX_Password
                 }
                 Window.Current.Activate();
             }
-
-
-            CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
-            ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
-            titleBar.ButtonBackgroundColor = Colors.Transparent;
-            titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
         }
 
         void OnNavigationFailed(object sender, NavigationFailedEventArgs e)

--- a/GX Password/App.xaml.cs
+++ b/GX Password/App.xaml.cs
@@ -5,11 +5,14 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.VoiceCommands;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Media.SpeechRecognition;
 using Windows.Storage;
+using Windows.UI;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -30,12 +33,12 @@ namespace GX_Password
 
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-#if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                this.DebugSettings.EnableFrameRateCounter = true;
-            }
-#endif
+//#if DEBUG
+//            if (System.Diagnostics.Debugger.IsAttached)
+//            {
+//                this.DebugSettings.EnableFrameRateCounter = true;
+//            }
+//#endif
 			Frame rootFrame = Window.Current.Content as Frame;
 
             if (rootFrame == null)
@@ -59,6 +62,12 @@ namespace GX_Password
                 }
                 Window.Current.Activate();
             }
+
+
+            CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
+            ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
+            titleBar.ButtonBackgroundColor = Colors.Transparent;
+            titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
         }
 
         void OnNavigationFailed(object sender, NavigationFailedEventArgs e)

--- a/GX Password/FluentDesignDictionary.xaml
+++ b/GX Password/FluentDesignDictionary.xaml
@@ -1,0 +1,48 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:GX_Password"
+    xmlns:W10FCU="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 5)">
+    
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <!--https://docs.microsoft.com/es-mx/windows/uwp/style/acrylic#custom-acrylic-brush-->
+            <W10FCU:AcrylicBrush x:Key="MainAcrylicBrush"                          
+                          BackgroundSource="HostBackdrop"
+                          TintColor="#66FFFFFF"
+                          TintOpacity="0.8"
+                          FallbackColor="#19000000" />
+
+            <Style x:Key="btnStyle" TargetType="Button" BasedOn="{StaticResource ButtonRevealStyle}">
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="Padding" Value="2" />
+                <Setter Property="Margin" Value="0,2,0,2" />
+            </Style>
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <SolidColorBrush x:Key="MainAcrylicBrush"
+                             Color="{ThemeResource SystemBaseHighColor}" />
+
+            <Style x:Key="btnStyle" TargetType="Button">
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="Padding" Value="2" />
+                <Setter Property="Margin" Value="0,2,0,2" />
+            </Style>
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Dark">
+            <W10FCU:AcrylicBrush x:Key="MainAcrylicBrush"                          
+                          BackgroundSource="HostBackdrop"
+                          TintColor="#CC000000"
+                          TintOpacity="0.8"
+                          FallbackColor="#66FFFFFF" />
+
+            <Style x:Key="btnStyle" TargetType="Button" BasedOn="{StaticResource ButtonRevealStyle}">
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="Padding" Value="2" />
+                <Setter Property="Margin" Value="0,2,0,2" />
+            </Style>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/GX Password/GX Password.csproj
+++ b/GX Password/GX Password.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>GX Password</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15063.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
@@ -168,6 +168,11 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="FluentDesignDictionary.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Page>
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -179,11 +184,10 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsMobile, Version=10.0.15063.0">
-      <Name>Windows Mobile Extensions for the UWP %28WindowsMobile, Version=10.0.15063.0%29</Name>
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/GX Password/MainPage.xaml
+++ b/GX Password/MainPage.xaml
@@ -7,7 +7,11 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" SizeChanged="MainChanged">
+    <Page.Resources>
+        <ResourceDictionary Source="FluentDesignDictionary.xaml" />
+    </Page.Resources>
+
+    <Grid Background="{StaticResource MainAcrylicBrush}" SizeChanged="MainChanged">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
 			<RowDefinition Height="*" />
@@ -17,14 +21,15 @@
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 
-		<StackPanel Grid.Row="0" Background="{ThemeResource SystemControlForegroundAccentBrush}" Padding="10" Visibility="Visible">
-			<TextBlock Text="GX Password" FontWeight="Bold" VerticalAlignment="Bottom"/>
+		<StackPanel Grid.Row="0" Padding="10" Visibility="Visible">
+			<TextBlock Text="GX Password" FontWeight="Bold" VerticalAlignment="Bottom"
+                       Style="{ThemeResource CaptionTextBlockStyle}" />
 		</StackPanel>
 
 		<StackPanel Grid.Row="1" Padding="10">
 			<StackPanel Padding="0,5,0,10">
 				<TextBlock x:Uid="yourPass" Text="Your New Password:" HorizontalAlignment="Left" Padding="2"/>
-				<TextBox x:Name="P" Text=""/>
+				<TextBox x:Name="P" Text="" FocusVisualPrimaryBrush="{ThemeResource SystemControlBackgroundAltMediumBrush}"  />
 			</StackPanel>
 			<StackPanel>
 				<TextBlock x:Uid="passLeng" Text="Password Length:"/>
@@ -32,14 +37,14 @@
 			</StackPanel>
 			<StackPanel Padding="3,0,3,6">
 				<TextBlock x:Uid="passOpt" Text="Password Option:"/>
-				<ToggleSwitch x:Uid="sTsNumb"  x:Name="tsNumb" IsOn="True" OffContent="Disabled Numbers" OnContent="Enabled Numbers" Padding="2"/>
-				<ToggleSwitch x:Uid="sTsLett"  x:Name="tsLett" IsOn="True" OffContent="Disabled Letters" OnContent="Enabled Letters" Padding="2"/>
+				<ToggleSwitch x:Uid="sTsNumb" x:Name="tsNumb" IsOn="True" OffContent="Disabled Numbers" OnContent="Enabled Numbers" Padding="2"/>
+				<ToggleSwitch x:Uid="sTsLett" x:Name="tsLett" IsOn="True" OffContent="Disabled Letters" OnContent="Enabled Letters" Padding="2"/>
 				<ToggleSwitch x:Uid="sTsSymb" x:Name="tsSymb" OffContent="Disabled Symbols" OnContent="Enabled Symbols" Padding="2"/>
 				<ToggleSwitch x:Uid="sTsSimi" x:Name="tsSimi" OffContent="Disabled Similar Characters" OnContent="Enabled Similar Characters" Padding="2"/>
 			</StackPanel>
 			<StackPanel Padding="0,5,0,10">
-				<Button x:Uid="sBtOk" x:Name="btOK" Content="Generate Password" HorizontalAlignment="Stretch" Padding="2" Margin="0,0,0,5" Click="btOK_click"/>
-				<Button x:Uid="sBtClipboard" x:Name="btClipboard" Content="Clipboard" HorizontalAlignment="Stretch" Padding="2" Click="btClipboard_click"/>
+				<Button x:Uid="sBtOk" x:Name="btOK" Content="Generate Password" Style="{StaticResource btnStyle}" Click="btOK_click"/>
+                <Button x:Uid="sBtClipboard" x:Name="btClipboard" Content="Clipboard" Style="{StaticResource btnStyle}" Click="btClipboard_click"/>
 			</StackPanel>
 		</StackPanel>
 	</Grid>

--- a/GX Password/MainPage.xaml.cs
+++ b/GX Password/MainPage.xaml.cs
@@ -43,17 +43,24 @@ namespace GX_Password
 			}
 			if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.ApplicationView"))
 			{
-				var titleBar = ApplicationView.GetForCurrentView().TitleBar;
-				if (titleBar != null)
-				{
-					titleBar.ButtonBackgroundColor = colorBar.Color;
-					titleBar.BackgroundColor = colorBar.Color;
-				}
-			}
+				ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;				
+
+                if (ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.XamlCompositionBrushBase"))
+                {
+                    CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
+                    titleBar.ButtonBackgroundColor = Colors.Transparent;
+                    titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+                }
+                else if (titleBar != null)
+                {
+                    titleBar.ButtonBackgroundColor = colorBar.Color;
+                    titleBar.BackgroundColor = colorBar.Color;
+                }
+            }
 			Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().IsScreenCaptureEnabled = false;
 		}
 
-		private string gen(int lenPass, bool text, bool numb, bool sym, bool simi)
+        private string gen(int lenPass, bool text, bool numb, bool sym, bool simi)
 		{
 			string password = "";
 			int[] simiArray = new int[190];


### PR DESCRIPTION
# Changes
- Acrylic material
- Light theme
- Dark theme
- High contrast theme
- Button reveal

All changes were made according to the fluent design documentation.
https://docs.microsoft.com/es-mx/windows/uwp/style/

## Notes
It was needed to change the target version to build 16299 (Fall Creators Update) for being able to use fluent design.
_I do not know how it could affect to the Creators Update (15063) version._

By default it requests the Light theme, it could be changed on the app.xaml file by deleting the `RequestedTheme="Light"` line.
